### PR TITLE
Provide a sane default when no workspace is open.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,17 @@ import * as constants from './constants';
 import { Command } from './command';
 
 let oldEnvDiff = {};
-let command = new Command(vscode.workspace.rootPath);
+let rpath = vscode.workspace['workspaceFolders'];
+if (rpath && rpath[0] && rpath[0]['uri']['path']) {
+    rpath = rpath[0]['uri']['path'];
+} else {
+    if (vscode.workspace['rootPath']) {
+        rpath = vscode.workspace['rootPath'];
+    } else {
+        rpath = process.env['HOME'];
+    }
+}
+let command = new Command(rpath);
 let watcher = vscode.workspace.createFileSystemWatcher(command.rcPath, true);
 let displayError = (e) =>
     vscode.window.showErrorMessage(constants.messages.error(e));


### PR DESCRIPTION
vscode-direnv only gets one chance to launch its defaults, and it has been failing for me because when `code` is opened without a workspace (folder), the value of `vscode.workspace.rootPath` is `undefined`. This changes this so that the new `vscode.workspace.workspaceFolders` API is used, if defined (keeps compatibility with earlier versions of `code`); then it tries `vscode.workspace.rootPath`, and then it falls back to `process.env.HOME`. This latter may not be "safe" in a Windows environment, but I’m not sure that `direnv` works in a Windows environment.