### PR TITLE
run synchronously on process load, and restart extension host on change

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,16 @@
 'use strict';
 
-export function assign(destination: any, ...sources: any[]): any {
-    sources.forEach(source => Object.keys(source).forEach((key) => destination[key] = source[key]));
-    return destination;
+export function assign(destination: any, ...sources: any[]): number {
+    let changes = 0
+    sources.forEach(source => Object.keys(source).forEach((key) => {
+        if (source[key] != destination[key]) {
+            changes += 1
+            if (source[key] == null) {
+                delete destination[key]
+            } else {
+                destination[key] = source[key]
+            }
+        }
+    }));
+    return changes
 }


### PR DESCRIPTION
#12 made me think, it seems like the only way to guarantee direnv is setup before other extensions is to do it both synchronously (no promises in the initialization code) and at process startup (otherwise it depends on extension activation order).

When reloading, it actually causes the extension host to restart because again, that seems like the only reliable way to ensure the new env is applied.

Which makes for a pretty badly behaved extension in some ways (it takes effect even if it's deactivated), but I don't see much alternative if we want to guarantee it happens first.